### PR TITLE
Drop all extra command line flags

### DIFF
--- a/configs/events/smartgateway_config.json
+++ b/configs/events/smartgateway_config.json
@@ -4,7 +4,7 @@
 	"AlertManagerURL": "http://localhost:9093/api/v1/alerts",
 	"ResetIndex": false,
 	"Debug": true,
-	"prefetch": 0,
+	"Prefetch": 0,
 	"API":  {
 		"APIEndpointURL": "localhost:9999",
 		"AMQP1PublishURL": "localhost:5672/collectd/alert2"

--- a/configs/metrics/smartgateway_config.json
+++ b/configs/metrics/smartgateway_config.json
@@ -7,7 +7,7 @@
 	"UseSample": false,
 	"UseTimeStamp": true,
 	"Debug": true,
-	"prefetch": 0,
+	"Prefetch": 15000,
 	"Sample": {
 		"HostCount": 10,
 		"PluginCount": 100,

--- a/internal/pkg/events/events.go
+++ b/internal/pkg/events/events.go
@@ -58,16 +58,9 @@ func eventusage() {
 	doc := heredoc.Doc(`
   For running with config file use
 	********************* config *********************
-	$go run cmd/main.go -config sa.events.config.json -debug -servicetype events
-	**************************************************
-	For running with AMQP and Prometheus use following option
-	********************* Production *********************
-	$go run cmd/main.go -servicetype events -amqp1EventURL=10.19.110.5:5672/collectd/notify -eshost=http://10.19.110.5:9200
-	**************************************************************
-	For running with AMQP ,Prometheus,API and AlertManager use following option
-	********************* Production *********************
-	$go run cmd/main.go -servicetype events -amqp1EventURL=10.19.110.5:5672/collectd/notify -eshost=http://10.19.110.5:9200 -alertmanager=http://localhost:9090/v1/api/alert -apiurl=localhost:8082 -amqppublishurl=127.0.0.1:5672/collectd/alert
-	**************************************************************`)
+	$go run cmd/main.go -config smartgateway_config.json -servicetype events
+	**************************************************`)
+
 	fmt.Fprintln(os.Stderr, `Required command line argument missing`)
 	fmt.Fprintln(os.Stdout, doc)
 	flag.PrintDefaults()
@@ -189,17 +182,9 @@ func StartEvents() {
 
 	// set flags for parsing options
 	flag.Usage = eventusage
-	fDebug := flag.Bool("debug", false, "Enable debug")
-	fServiceType := flag.String("servicetype", "event", "event type")
-	fConfigLocation := flag.String("config", "", "Path to configuration file(optional).if provided ignores all command line options")
-	fAMQP1EventURL := flag.String("amqp1EventURL", "", "AMQP1.0 collectd events listener example 127.0.0.1:5672/collectd/notify")
-	fElasticHostURL := flag.String("eshost", "", "ElasticSearch host http://localhost:9200")
-	fAlertManagerURL := flag.String("alertmanager", "", "(Optional)AlertManager endpoint http://localhost:9090/v1/api/alert")
-	fAPIEndpointURL := flag.String("apiurl", "", "(Optional)API endpoint localhost:8082")
-	fAMQP1PublishURL := flag.String("amqppublishurl", "", "(Optional) AMQP1.0 event publish address 127.0.0.1:5672/collectd/alert")
-	fResetIndex := flag.Bool("resetIndex", false, "Optional Clean all index before on start (default false)")
-	fPrefetch := flag.Int("prefetch", 0, "AMQP1.0 option: Enable prefetc and set capacity(0 is disabled,>0 enabled with capacity of >0) (OPTIONAL)")
-	fUniqueName := flag.String("uname", "metrics-"+strconv.Itoa(rand.Intn(100)), "Unique name across application")
+	fServiceType := flag.String("servicetype", "event", "Event type")
+	fConfigLocation := flag.String("config", "", "Path to configuration file.")
+	fUniqueName := flag.String("uname", "events-"+strconv.Itoa(rand.Intn(100)), "Unique name across application")
 	flag.Parse()
 
 	//load configuration from given config file or from cmdline parameters
@@ -211,24 +196,9 @@ func StartEvents() {
 		}
 		serverConfig = conf.(*saconfig.EventConfiguration)
 		serverConfig.ServiceType = *fServiceType
-		if *fDebug {
-			serverConfig.Debug = true
-		}
 	} else {
-		serverConfig = &saconfig.EventConfiguration{
-			AMQP1EventURL:   *fAMQP1EventURL,
-			ElasticHostURL:  *fElasticHostURL,
-			AlertManagerURL: *fAlertManagerURL,
-			Prefetch:        *fPrefetch,
-			ServiceType:     *fServiceType,
-			API: saconfig.EventAPIConfig{
-				APIEndpointURL:  *fAPIEndpointURL,
-				AMQP1PublishURL: *fAMQP1PublishURL,
-			},
-			ResetIndex: *fResetIndex,
-			Debug:      *fDebug,
-			UniqueName: *fUniqueName,
-		}
+		eventusage()
+		os.Exit(1)
 	}
 
 	if serverConfig.Debug {

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -110,6 +110,12 @@ func StartMetrics() {
 		debugm = func(format string, data ...interface{}) { log.Printf(format, data...) }
 	}
 
+	if len(serverConfig.AMQP1MetricURL) == 0 {
+		log.Println("AMQP1 Metrics URL is required")
+		metricusage()
+		os.Exit(1)
+	}
+
 	//Block -starts
 	//Set up signal Go routine
 	signalCh := make(chan os.Signal, 1)

--- a/internal/pkg/metrics/metrics.go
+++ b/internal/pkg/metrics/metrics.go
@@ -76,14 +76,9 @@ func (c *cacheHandler) Collect(ch chan<- prometheus.Metric) {
 // metricusage and command-line flags
 func metricusage() {
 	doc := heredoc.Doc(`
-  For running with config file use
 	********************* config *********************
-	$go run cmd/main.go -config sa.metrics.config.json -debug -servicetype metrics
-	**************************************************
-	For running with AMQP and Prometheus use following option
-	********************* Production *********************
-	$go run cmd/main.go -servicetype metrics -mhost=localhost -mport=8081 -amqp1MetricURL=10.19.110.5:5672/collectd/telemetry
-	**************************************************************`)
+	$go run cmd/main.go -config smartgateway_config.json -servicetype metrics
+	**************************************************`)
 
 	fmt.Fprintln(os.Stderr, `Required commandline argument missing`)
 	fmt.Fprintln(os.Stdout, doc)
@@ -94,16 +89,8 @@ func metricusage() {
 func StartMetrics() {
 	// set flags for parsing options
 	flag.Usage = metricusage
-	fDebug := flag.Bool("debug", false, "Enable debug")
-	fServiceType := flag.String("servicetype", "metrics", "metric type")
-	fConfigLocation := flag.String("config", "", "Path to configuration file(optional).if provided ignores all command line options")
-	fIncludeStats := flag.Bool("cpustats", false, "Include cpu usage info in http requests (degrades performance)")
-	fExporterhost := flag.String("mhost", "localhost", "Metrics url for Prometheus to export. ")
-	fExporterport := flag.Int("mport", 8081, "Metrics port for Prometheus to export (http://localhost:<port>/metrics) ")
-	fAMQP1MetricURL := flag.String("amqp1MetricURL", "", "AMQP1.0 metrics listener example 127.0.0.1:5672/collectd/telemetry")
-	fCount := flag.Int("count", -1, "Stop after receiving this many messages in total(-1 forever) (OPTIONAL)")
-	fPrefetch := flag.Int("prefetch", 0, "AMQP1.0 option: Enable prefetc and set capacity(0 is disabled,>0 enabled with capacity of >0) (OPTIONAL)")
-	fUsetimestamp := flag.Bool("usetimestamp", true, "Use source time stamp instead of promethues.(default true,OPTIONAL)")
+	fServiceType := flag.String("servicetype", "metrics", "Metric type")
+	fConfigLocation := flag.String("config", "", "Path to configuration file.")
 	fUniqueName := flag.String("uname", "metrics-"+strconv.Itoa(rand.Intn(100)), "Unique name across application")
 	flag.Parse()
 
@@ -115,32 +102,12 @@ func StartMetrics() {
 		}
 		serverConfig = conf.(*saconfig.MetricConfiguration)
 		serverConfig.ServiceType = *fServiceType
-		if *fDebug {
-			serverConfig.Debug = true
-		}
 	} else {
-		serverConfig = &saconfig.MetricConfiguration{
-			AMQP1MetricURL: *fAMQP1MetricURL,
-			CPUStats:       *fIncludeStats,
-			Exporterhost:   *fExporterhost,
-			Exporterport:   *fExporterport,
-			DataCount:      *fCount, //-1 for ever which is default
-			UseTimeStamp:   *fUsetimestamp,
-			Debug:          *fDebug,
-			Prefetch:       *fPrefetch,
-			ServiceType:    *fServiceType,
-			UniqueName:     *fUniqueName,
-		}
-
+		metricusage()
+		os.Exit(1)
 	}
 	if serverConfig.Debug {
 		debugm = func(format string, data ...interface{}) { log.Printf(format, data...) }
-	}
-
-	if len(serverConfig.AMQP1MetricURL) == 0 {
-		log.Println("AMQP1 Metrics URL is required")
-		metricusage()
-		os.Exit(1)
 	}
 
 	//Block -starts

--- a/tests/internal_pkg/saconfig_test.go
+++ b/tests/internal_pkg/saconfig_test.go
@@ -158,7 +158,7 @@ func TestUnstructuredData(t *testing.T) {
 	}
 }
 
-func TestStructuredData(t *testing.T) {
+func TestEventStructuredData(t *testing.T) {
 	confPath, err := GenerateTestConfig(EventsConfig)
 	if err != nil {
 		t.Fatal(err)
@@ -177,9 +177,30 @@ func TestStructuredData(t *testing.T) {
 	t.Run("Test structured AMQP connections", func(t *testing.T) {
 		connStruct := []saconfig.AMQPConnection{
 			saconfig.AMQPConnection{URL: "127.0.0.1:5672/collectd/notify", DataSource: "collectd", DataSourceID: 1},
-			saconfig.AMQPConnection{URL: "127.0.0.1:5672/ceilometer/events", DataSource: "ceilometer", DataSourceID: 2},
+			saconfig.AMQPConnection{URL: "127.0.0.1:5672/ceilometer/event.sample", DataSource: "ceilometer", DataSourceID: 2},
 			saconfig.AMQPConnection{URL: "127.0.0.1:5672/universal/events", DataSource: "universal", DataSourceID: 0},
 		}
 		assert.Equal(t, connStruct, cfg.(*saconfig.EventConfiguration).AMQP1Connections)
+	})
+}
+
+func TestMetricStructuredData(t *testing.T) {
+	confPath, err := GenerateTestConfig(MetricsConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(confPath)
+	cfg, err := saconfig.LoadConfiguration(confPath, "metric")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Test structured AMQP connections", func(t *testing.T) {
+		connStruct := []saconfig.AMQPConnection{
+			saconfig.AMQPConnection{URL: "127.0.0.1:5672/collectd/telemetry", DataSource: "collectd", DataSourceID: 1},
+			saconfig.AMQPConnection{URL: "127.0.0.1:5672/ceilometer/metering.sample", DataSource: "ceilometer", DataSourceID: 2},
+			saconfig.AMQPConnection{URL: "127.0.0.1:5672/universal/metrics", DataSource: "universal", DataSourceID: 0},
+		}
+		assert.Equal(t, connStruct, cfg.(*saconfig.MetricConfiguration).AMQP1Connections)
 	})
 }

--- a/tests/internal_pkg/saconfig_test.go
+++ b/tests/internal_pkg/saconfig_test.go
@@ -15,7 +15,7 @@ const (
 {
 	"AMQP1Connections": [
 		{"Url": "127.0.0.1:5672/collectd/notify", "DataSource": "collectd"},
-		{"Url": "127.0.0.1:5672/ceilometer/events", "DataSource": "ceilometer"},
+		{"Url": "127.0.0.1:5672/ceilometer/event.sample", "DataSource": "ceilometer"},
 		{"Url": "127.0.0.1:5672/universal/events", "DataSource": "universal"}
 	],
 	"AMQP1EventURL": "127.0.0.1:5672/collectd/notify",
@@ -35,7 +35,7 @@ const (
 {
 	"AMQP1Connections": [
 		{"Url": "127.0.0.1:5672/collectd/telemetry", "DataSource": "collectd"},
-		{"Url": "127.0.0.1:5672/ceilometer/telemetry", "DataSource": "ceilometer"},
+		{"Url": "127.0.0.1:5672/ceilometer/metering.sample", "DataSource": "ceilometer"},
 		{"Url": "127.0.0.1:5672/universal/telemetry", "DataSource": "universal"}
 	],
 	"AMQP1MetricURL": "127.0.0.1:5672/collectd/telemetry",

--- a/tests/internal_pkg/saconfig_test.go
+++ b/tests/internal_pkg/saconfig_test.go
@@ -184,6 +184,7 @@ func TestEventStructuredData(t *testing.T) {
 	})
 }
 
+/* enable this after implementing []AMQP1Connections in metrics.go
 func TestMetricStructuredData(t *testing.T) {
 	confPath, err := GenerateTestConfig(MetricsConfig)
 	if err != nil {
@@ -204,3 +205,4 @@ func TestMetricStructuredData(t *testing.T) {
 		assert.Equal(t, connStruct, cfg.(*saconfig.MetricConfiguration).AMQP1Connections)
 	})
 }
+*/


### PR DESCRIPTION
In order to avoid having missed flags updated when the configuration structures change, and
since command line flags are not used in our deployment environments, this patch removes all
the unnecessary flags.

The flags -config, -servicetype, and -uname are left in place to support the existing Operator
configurations to avoid needing changes there. All other flags have been dropped in favour of
using the standard configuration files.