### PR TITLE
Fix and test for list of ceilometer metrics

### DIFF
--- a/tests/internal_pkg/messages/formatCeilometerMessage.py
+++ b/tests/internal_pkg/messages/formatCeilometerMessage.py
@@ -1,0 +1,174 @@
+import json
+from jsonschema import validate, ValidationError
+import string
+import sys, getopt
+
+testSchema = {
+    'type':'object',
+    'properties': {
+        'testInput':
+        {
+            'type':'object',
+            'properties': {
+                'request': {
+                    'type':'object',
+                    'properties': {
+                        'oslo.message': {'type':'string'},
+                    },
+                    'required': ['oslo.message']
+                },
+            },
+            'required':['request']
+        },
+    },
+    'required': ['testInput']
+}
+
+osloSchema = {
+    'type':'object',
+    'properties': {
+        'publisher_id': {'type':'string'},
+        'payload':      {'type':'array'},
+    },
+    'required': ['publisher_id','payload']
+}
+
+payloadSchema = {
+    'type':'object',
+    'properties': {
+        'counter_name':   {'type': 'string'},
+        'resource_id':    {'type': 'string'},
+        'counter_volume': {'type': 'number'},
+    },
+    'required': ['counter_name','resource_id','counter_volume']
+}
+
+
+def generateResultsFromJSON(data):
+    try:
+        validate(instance=data, schema=testSchema)
+        osloMessageJSON = data['testInput']['request']['oslo.message']
+
+        message = json.loads(osloMessageJSON)
+        validate(instance=message,schema=osloSchema)
+
+        results = []
+        for pl in message['payload']:
+            validate(instance=pl,schema=payloadSchema)
+
+            pluginAttr = pl["counter_name"].split('.')
+            pt = ''
+            typeInstance = ''
+            if len(pluginAttr) > 1:
+                pt = pluginAttr[1] 
+                if len(pluginAttr) > 2:
+                    typeInstance = pluginAttr[2]
+            else:
+                pt = pluginAttr[0]
+            
+            pluginInstance = pl['resource_id']
+            plugin = pluginAttr[0]
+            publisher = message['publisher_id']
+
+            metricGenerated = {
+                'publisher': publisher,
+                'plugin': plugin,
+                'plugin_instance': pl['resource_id'],
+                'type': pt,
+                'values': [pl['counter_volume']],
+                'name': plugin,
+                'key': publisher,
+                'item_key': genItemKey(plugin, pluginInstance,pt, typeInstance),
+                'type_instance': typeInstance,
+                'labels': genLabels(pl, plugin, typeInstance, pluginInstance,publisher),
+                'description': genDescription(pl, plugin, pt),
+                'metric_name': genMetricName(plugin, pt, typeInstance),
+            }
+
+            results.append(metricGenerated)
+        return results
+
+    except ValidationError as e:
+            print(e)
+            print("---------")
+            print(e.absolute_path)
+        
+            print("---------")
+            print(e.absolute_schema_path)
+
+def genMetricName(plugin, typ, typeInstance):
+    name = ["ceilometer", plugin]
+    if plugin != typ:
+        name.append(typ)
+    if typeInstance:
+        name.append(typeInstance)
+    return '_'.join(name)
+
+
+def genDescription(payload, plugin, typ):
+    id = payload["counter_name"]
+    dstype = 'counter'
+    if 'counter_type' in payload:
+        dstype = payload['counter_type']
+    return "Service Telemetry exporter: '{plugin}' Type: '{Type}' Dstype: '{Dstype}' Dsname: '{ID}'".format(plugin=plugin, Type=typ, Dstype=dstype, ID=id)
+
+
+def genItemKey(plugin, pluginInstance, tpe, typeInstance):
+    parts = [plugin]
+
+    if plugin != tpe:
+        parts.append(tpe)
+    if pluginInstance:
+        parts.append(pluginInstance)
+    if typeInstance:
+        parts.append(typeInstance)
+    return "_".join(parts)
+
+def genLabels(payload, plugin, typeInstance, pluginInstance, publisher):
+    labels = {"publisher": publisher}
+    if typeInstance:
+        labels[plugin] = typeInstance
+    else:
+        labels[plugin] = pluginInstance
+    
+    if "counter_type" in payload:
+        labels["type"] = payload["counter_type"]
+    else:
+        labels["type"] = "base"
+    if "project_id" in payload:
+        labels["project"] = payload["project_id"]
+    if "resource_id" in payload:
+        labels["resource"] = payload["resource_id"]
+    if "counter_unit" in payload:
+        labels["unit"] = payload["counter_unit"]
+    if "counter_name" in payload:
+        labels["counter"] = payload["counter_name"]
+    return labels
+
+def main(cmd, argv):
+    inputFile = ''
+    testName = ''
+
+    try:
+        opts, args = getopt.getopt(argv,"f:t:",["file=","test="])
+
+        for opt, arg in opts:
+            if opt in ('-f','--file'):
+                inputFile = arg
+            elif opt in ('-t','--test'):
+                testName = arg
+
+        with open(inputFile,'r') as jsonFile:
+            data = json.load(jsonFile)
+            if testName in data:
+                data[testName]["validatedResults"] = generateResultsFromJSON(data[testName])
+                print(json.dumps(data, indent=2))
+            else:
+                print("Could not find test '%s' in %s" % (testName,inputFile))
+
+    except getopt.GetoptError:
+        print("%s -f <filepath> -t <testname>" % cmd)
+
+
+if __name__ == "__main__":
+    main(sys.argv[0],sys.argv[1:])

--- a/tests/internal_pkg/messages/metric-tests.json
+++ b/tests/internal_pkg/messages/metric-tests.json
@@ -1,0 +1,134 @@
+{
+  "CeilometerMetrics": {
+    "description": "test ceilometer metric parsing",
+    "testInput": {
+      "request": {
+        "oslo.version": "2.0",
+        "oslo.message": "{\"message_id\": \"37f64423-db31-4cfb-8c9d-06f9c0fad04a\", \"publisher_id\": \"telemetry.publisher.controller-0.redhat.local\", \"event_type\": \"metering\", \"priority\": \"SAMPLE\", \"payload\": [{\"source\": \"openstack\", \"counter_name\": \"disk.ephemeral.size\", \"counter_type\": \"gauge\", \"counter_unit\": \"GB\", \"counter_volume\": 0, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a54880-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"be55d63bd5d876a62ab52824104128eedfa0619386e8569e326ccef4dcf0d9db\"}, {\"source\": \"openstack\", \"counter_name\": \"disk.root.size\", \"counter_type\": \"gauge\", \"counter_unit\": \"GB\", \"counter_volume\": 1, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a55c80-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"bc0b987d71fe9f0d5d902347f22a0a20b2d975344b4c948572cae4dae553e960\"}, {\"source\": \"openstack\", \"counter_name\": \"compute.instance.booting.time\", \"counter_type\": \"gauge\", \"counter_unit\": \"sec\", \"counter_volume\": 10.839122, \"user_id\": null, \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a574d6-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"fd7f1e2fdb34b7beb836d0ead178289f7c36f39bcd68acfd0719848667c58a13\"}, {\"source\": \"openstack\", \"counter_name\": \"vcpus\", \"counter_type\": \"gauge\", \"counter_unit\": \"vcpu\", \"counter_volume\": 2, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a5821e-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"d3f107c2ef6bb1b06e1a9975d1f1ff0bdc51432adff39403db2a1f6a9773b99d\"}, {\"source\": \"openstack\", \"counter_name\": \"memory\", \"counter_type\": \"gauge\", \"counter_unit\": \"MB\", \"counter_volume\": 512, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a591dc-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"9dcf78e3cd43e7fcd66cda5cf33511150e79a086a634bd9d087bb567e4985980\"}], \"timestamp\": \"2020-09-14 16:12:49.954128\"}"
+      },
+      "context": {}
+    },
+    "validatedResults": [
+      {
+        "publisher": "telemetry.publisher.controller-0.redhat.local",
+        "plugin": "disk",
+        "plugin_instance": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+        "type": "ephemeral",
+        "values": [
+          0
+        ],
+        "name": "disk",
+        "key": "telemetry.publisher.controller-0.redhat.local",
+        "item_key": "disk_ephemeral_d8bd99b6-6fd8-4c02-a2e3-efbf596df636_size",
+        "type_instance": "size",
+        "labels": {
+          "publisher": "telemetry.publisher.controller-0.redhat.local",
+          "disk": "size",
+          "type": "gauge",
+          "project": "e56191ef77744c599dbcecae6af176bb",
+          "resource": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+          "unit": "GB",
+          "counter": "disk.ephemeral.size"
+        },
+        "description": "Service Telemetry exporter: 'disk' Type: 'ephemeral' Dstype: 'gauge' Dsname: 'disk.ephemeral.size'",
+        "metric_name": "ceilometer_disk_ephemeral_size"
+      },
+      {
+        "publisher": "telemetry.publisher.controller-0.redhat.local",
+        "plugin": "disk",
+        "plugin_instance": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+        "type": "root",
+        "values": [
+          1
+        ],
+        "name": "disk",
+        "key": "telemetry.publisher.controller-0.redhat.local",
+        "item_key": "disk_root_d8bd99b6-6fd8-4c02-a2e3-efbf596df636_size",
+        "type_instance": "size",
+        "labels": {
+          "publisher": "telemetry.publisher.controller-0.redhat.local",
+          "disk": "size",
+          "type": "gauge",
+          "project": "e56191ef77744c599dbcecae6af176bb",
+          "resource": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+          "unit": "GB",
+          "counter": "disk.root.size"
+        },
+        "description": "Service Telemetry exporter: 'disk' Type: 'root' Dstype: 'gauge' Dsname: 'disk.root.size'",
+        "metric_name": "ceilometer_disk_root_size"
+      },
+      {
+        "publisher": "telemetry.publisher.controller-0.redhat.local",
+        "plugin": "compute",
+        "plugin_instance": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+        "type": "instance",
+        "values": [
+          10.839122
+        ],
+        "name": "compute",
+        "key": "telemetry.publisher.controller-0.redhat.local",
+        "item_key": "compute_instance_d8bd99b6-6fd8-4c02-a2e3-efbf596df636_booting",
+        "type_instance": "booting",
+        "labels": {
+          "publisher": "telemetry.publisher.controller-0.redhat.local",
+          "compute": "booting",
+          "type": "gauge",
+          "project": "e56191ef77744c599dbcecae6af176bb",
+          "resource": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+          "unit": "sec",
+          "counter": "compute.instance.booting.time"
+        },
+        "description": "Service Telemetry exporter: 'compute' Type: 'instance' Dstype: 'gauge' Dsname: 'compute.instance.booting.time'",
+        "metric_name": "ceilometer_compute_instance_booting"
+      },
+      {
+        "publisher": "telemetry.publisher.controller-0.redhat.local",
+        "plugin": "vcpus",
+        "plugin_instance": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+        "type": "vcpus",
+        "values": [
+          2
+        ],
+        "name": "vcpus",
+        "key": "telemetry.publisher.controller-0.redhat.local",
+        "item_key": "vcpus_d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+        "type_instance": "",
+        "labels": {
+          "publisher": "telemetry.publisher.controller-0.redhat.local",
+          "vcpus": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+          "type": "gauge",
+          "project": "e56191ef77744c599dbcecae6af176bb",
+          "resource": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+          "unit": "vcpu",
+          "counter": "vcpus"
+        },
+        "description": "Service Telemetry exporter: 'vcpus' Type: 'vcpus' Dstype: 'gauge' Dsname: 'vcpus'",
+        "metric_name": "ceilometer_vcpus"
+      },
+      {
+        "publisher": "telemetry.publisher.controller-0.redhat.local",
+        "plugin": "memory",
+        "plugin_instance": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+        "type": "memory",
+        "values": [
+          512
+        ],
+        "name": "memory",
+        "key": "telemetry.publisher.controller-0.redhat.local",
+        "item_key": "memory_d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+        "type_instance": "",
+        "labels": {
+          "publisher": "telemetry.publisher.controller-0.redhat.local",
+          "memory": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+          "type": "gauge",
+          "project": "e56191ef77744c599dbcecae6af176bb",
+          "resource": "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
+          "unit": "MB",
+          "counter": "memory"
+        },
+        "description": "Service Telemetry exporter: 'memory' Type: 'memory' Dstype: 'gauge' Dsname: 'memory'",
+        "metric_name": "ceilometer_memory"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #89 

This patch adjusts ceilometer metric parsing logic to handle metrics coming from multiple instances at once in a list object. Unit tests have been re factored as well and a python script included to help ease the process of creating correct output data for said unit tests.

I am working on testing this in STF right now and will post the results once that completes.