### PR TITLE
use literal string replacement rather than expansion

### DIFF
--- a/internal/pkg/events/incoming/ceilometer.go
+++ b/internal/pkg/events/incoming/ceilometer.go
@@ -105,7 +105,7 @@ func (evt *CeilometerEvent) sanitize(jsondata string) string {
 	// avoid getting payload data wrapped in array
 	item := rexForPayload.FindStringSubmatch(sanitized)
 	if len(item) == 2 {
-		sanitized = rexForPayload.ReplaceAllString(sanitized, fmt.Sprintf(`"payload":%s`, item[1]))
+		sanitized = rexForPayload.ReplaceAllLiteralString(sanitized, fmt.Sprintf(`"payload":%s`, item[1]))
 	}
 	return sanitized
 }


### PR DESCRIPTION
This is a pre-emptive fix related to https://github.com/infrawatch/smart-gateway/issues/93. This avoids ever having the same issue with ceilometer metrics as we did collectd metrics.