### PR TITLE
cherrypick hotfix

### DIFF
--- a/internal/pkg/metrics/incoming/ceilometer.go
+++ b/internal/pkg/metrics/incoming/ceilometer.go
@@ -152,15 +152,9 @@ func (c CeilometerMetric) GetKey() string {
 
 //GetItemKey returns name cache key analogically to CollectdMetric implementation
 func (c *CeilometerMetric) GetItemKey() string {
-	parts := []string{c.Plugin}
-	if c.Plugin != c.Type {
-		parts = append(parts, c.Type)
-	}
+	parts := []string{c.getwholeID()}
 	if c.PluginInstance != "" {
 		parts = append(parts, c.PluginInstance)
-	}
-	if c.TypeInstance != "" {
-		parts = append(parts, c.TypeInstance)
 	}
 	return strings.Join(parts, "_")
 }
@@ -223,13 +217,9 @@ func (c *CeilometerMetric) GetLabels() map[string]string {
 
 //GetMetricName ...
 func (c *CeilometerMetric) GetMetricName(index int) string {
-	nameParts := []string{"ceilometer", c.Plugin}
-	if c.Plugin != c.Type {
-		nameParts = append(nameParts, c.Type)
-	}
-	if c.TypeInstance != "" {
-		nameParts = append(nameParts, c.TypeInstance)
-	}
+	nameParts := []string{"ceilometer"}
+	cNameShards := strings.Split(c.getwholeID(), ".")
+	nameParts = append(nameParts, cNameShards...)
 	return strings.Join(nameParts, "_")
 }
 

--- a/internal/pkg/tsdb/prometheus.go
+++ b/internal/pkg/tsdb/prometheus.go
@@ -106,7 +106,8 @@ func NewPrometheusMetric(usetimestamp bool, format string, metric incoming.Metri
 		} else {
 			return nil, fmt.Errorf("did not find timestamp in metric payload: %s", ceilometer.Payload)
 		}
-		help = ceilometer.GetMetricDesc(index)
+		//help = ceilometer.GetMetricDesc(index)
+		help = ""
 		metricName = metricNameRe.ReplaceAllString(ceilometer.GetMetricName(index), "_")
 		labels = ceilometer.GetLabels()
 		value = ceilometer.Values[index]

--- a/tests/internal_pkg/messages/formatCeilometerMessage.py
+++ b/tests/internal_pkg/messages/formatCeilometerMessage.py
@@ -78,11 +78,11 @@ def generateResultsFromJSON(data):
                 'values': [pl['counter_volume']],
                 'name': plugin,
                 'key': publisher,
-                'item_key': genItemKey(plugin, pluginInstance,pt, typeInstance),
+                'item_key': genItemKey(pl, pluginInstance),
                 'type_instance': typeInstance,
                 'labels': genLabels(pl, plugin, typeInstance, pluginInstance,publisher),
                 'description': genDescription(pl, plugin, pt),
-                'metric_name': genMetricName(plugin, pt, typeInstance),
+                'metric_name': genMetricName(pluginAttr),
             }
 
             results.append(metricGenerated)
@@ -96,12 +96,9 @@ def generateResultsFromJSON(data):
             print("---------")
             print(e.absolute_schema_path)
 
-def genMetricName(plugin, typ, typeInstance):
-    name = ["ceilometer", plugin]
-    if plugin != typ:
-        name.append(typ)
-    if typeInstance:
-        name.append(typeInstance)
+def genMetricName(cNameParts):
+    name = ["ceilometer"]
+    name = name + cNameParts
     return '_'.join(name)
 
 
@@ -113,16 +110,11 @@ def genDescription(payload, plugin, typ):
     return "Service Telemetry exporter: '{plugin}' Type: '{Type}' Dstype: '{Dstype}' Dsname: '{ID}'".format(plugin=plugin, Type=typ, Dstype=dstype, ID=id)
 
 
-def genItemKey(plugin, pluginInstance, tpe, typeInstance):
-    parts = [plugin]
-
-    if plugin != tpe:
-        parts.append(tpe)
+def genItemKey(payload, pluginInstance):
+    key = [payload["counter_name"]]
     if pluginInstance:
-        parts.append(pluginInstance)
-    if typeInstance:
-        parts.append(typeInstance)
-    return "_".join(parts)
+       key.append(pluginInstance) 
+    return "_".join(key)
 
 def genLabels(payload, plugin, typeInstance, pluginInstance, publisher):
     labels = {"publisher": publisher}

--- a/tests/internal_pkg/messages/metric-tests.json
+++ b/tests/internal_pkg/messages/metric-tests.json
@@ -19,7 +19,7 @@
         ],
         "name": "disk",
         "key": "telemetry.publisher.controller-0.redhat.local",
-        "item_key": "disk_ephemeral_d8bd99b6-6fd8-4c02-a2e3-efbf596df636_size",
+        "item_key": "disk.ephemeral.size_d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
         "type_instance": "size",
         "labels": {
           "publisher": "telemetry.publisher.controller-0.redhat.local",
@@ -43,7 +43,7 @@
         ],
         "name": "disk",
         "key": "telemetry.publisher.controller-0.redhat.local",
-        "item_key": "disk_root_d8bd99b6-6fd8-4c02-a2e3-efbf596df636_size",
+        "item_key": "disk.root.size_d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
         "type_instance": "size",
         "labels": {
           "publisher": "telemetry.publisher.controller-0.redhat.local",
@@ -67,7 +67,7 @@
         ],
         "name": "compute",
         "key": "telemetry.publisher.controller-0.redhat.local",
-        "item_key": "compute_instance_d8bd99b6-6fd8-4c02-a2e3-efbf596df636_booting",
+        "item_key": "compute.instance.booting.time_d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
         "type_instance": "booting",
         "labels": {
           "publisher": "telemetry.publisher.controller-0.redhat.local",
@@ -79,7 +79,7 @@
           "counter": "compute.instance.booting.time"
         },
         "description": "Service Telemetry exporter: 'compute' Type: 'instance' Dstype: 'gauge' Dsname: 'compute.instance.booting.time'",
-        "metric_name": "ceilometer_compute_instance_booting"
+        "metric_name": "ceilometer_compute_instance_booting_time"
       },
       {
         "publisher": "telemetry.publisher.controller-0.redhat.local",


### PR DESCRIPTION
- (commit cherry picked from e345f58d6993883c7ef70b705e0dc3867827d3d5) Ceilometer metric panic on label retreival hotfix (#100) (#102)
- Use full ceilometer metric name in metric and cache (#103)
